### PR TITLE
Handle broken pipe errors when writing to stdout with --list.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -130,17 +130,15 @@ fn main() -> Result<(), std::io::Error> {
 
         // if list option is given, do not extract
         if matches.is_present("list") {
-            let result = writeln!(&mut stdout, "{}", file.name());
-            match result {
-                Ok(_) => { continue }
-                Err(err) => {
-                    return if err.kind() == io::ErrorKind::BrokenPipe {
+            if let Err(err)  = writeln!(&mut stdout, "{}", file.name())
+            {
+                  return if err.kind() == io::ErrorKind::BrokenPipe {
                         Ok(())
                     } else {
                         Err(err)
                     }
-                }
             }
+            continue;
         }
 
         if (&*file.name()).ends_with('/') {


### PR DESCRIPTION
This prevents a panic when partun is used in a shell pipeline and fills the pipe buffer after the consuming process exits. See this issue for additional info: https://github.com/rust-lang/rust/issues/46016

Also fixed a deprecation warning introduced in clap 3.1.0.